### PR TITLE
Fix: Show start dripping button and parse CO2tokenbalance to number

### DIFF
--- a/packages/react-app/src/components/PledgedReduceCO2.jsx
+++ b/packages/react-app/src/components/PledgedReduceCO2.jsx
@@ -12,19 +12,21 @@ import { StyledButton } from './buttons/StyledButton'
 import { StyledIcon } from './StyledIcon'
 import TokenBalance from './TokenBalance'
 
+const { ethers } = require('ethers')
 const { Text } = Typography
 
-const PledgedReduceCO2 = ({ isPledged }) => {
+// eslint-disable-next-line max-lines-per-function
+const PledgedReduceCO2 = ({ isPledged, address }) => {
   const router = useHistory()
-  const { userSigner, targetNetwork, address } = useContext(NetworkContext)
-  const { writeContracts } = useContext(WalletContext)
+  const { userSigner, targetNetwork } = useContext(NetworkContext)
+  const { writeContracts, contracts } = useContext(WalletContext)
   const [co2, setCo2] = useState('')
   const [pledging, setPledging] = useState()
   const [dripping, setDripping] = useState()
   const gasPrice = useGasPrice(targetNetwork, 'fast')
   const tx = Transactor(userSigner, gasPrice)
 
-  const CO2TokenBalance = useContractReader(writeContracts, 'CO2TokenContract', 'balanceOf', [address], HOOK_OPTIONS)
+  const CO2TokenBalance = useContractReader(contracts, 'CO2TokenContract', 'balanceOf', [address], HOOK_OPTIONS)
 
   return (
     <>
@@ -40,7 +42,7 @@ const PledgedReduceCO2 = ({ isPledged }) => {
       )}
 
       {isPledged ? (
-        CO2TokenBalance === 0 ? (
+        Number(ethers.utils.formatUnits(CO2TokenBalance || 0, 18)) === 0 ? (
           <>
             <Row justify="start" style={{ marginBottom: '2rem' }}>
               <Col>

--- a/packages/react-app/src/pages/Pledge.jsx
+++ b/packages/react-app/src/pages/Pledge.jsx
@@ -4,11 +4,13 @@ import { Col, Row, Typography } from 'antd'
 import PledgeDisplay from '../components/pledge/PledgeDisplay'
 import PledgedReduceCO2 from '../components/PledgedReduceCO2'
 import { StyledIcon } from '../components/StyledIcon'
+import { NetworkContext } from '../contexts/NetworkContext'
 import { WalletContext } from '../contexts/WalletContext'
 
 const { Title, Paragraph } = Typography
 
 const Pledge = () => {
+  const { address } = useContext(NetworkContext)
   const { isPledged } = useContext(WalletContext)
 
   return (
@@ -46,9 +48,11 @@ const Pledge = () => {
         </Paragraph>
       </Col>
 
-      <Col xl={13} xs={22}>
-        <PledgedReduceCO2 isPledged={isPledged} />
-      </Col>
+      {address && (
+        <Col xl={13} xs={22}>
+          <PledgedReduceCO2 isPledged={isPledged} address={address} />
+        </Col>
+      )}
     </Row>
   )
 }


### PR DESCRIPTION
## Pull request type
Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe): 

[Clickup Task](paste-here-clickup-task-link)

## What is the current behavior?
After pledged the button to start dripping is not showing

## What is the new behavior?
Now show the start dripping button and parse CO2TokenBalance to use in ternary operator correctly

## How can your PR break the app?
## Other information
## Screenshots (optional)

deployed app:

![deployed app](https://user-images.githubusercontent.com/66321949/158619927-c3b95762-72ca-4a0b-b4ee-bc8bae35176a.png)

localhost:

![localhost](https://user-images.githubusercontent.com/66321949/158619984-dd31e1a9-0731-4c1e-9a34-eae79ff1d80e.png)

